### PR TITLE
Kubectl explain

### DIFF
--- a/pkg/kubectl-explain/ExplainPanel.vue
+++ b/pkg/kubectl-explain/ExplainPanel.vue
@@ -1,0 +1,234 @@
+<script>
+import { mapGetters } from 'vuex';
+import Markdown from '@shell/components/Markdown';
+
+export default {
+  name: 'ExplainPanel',
+
+  components: { Markdown },
+
+  props: {
+    definition: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      isOpen: false,
+      expanded: {}
+    };
+  },
+
+  computed: {
+    ...mapGetters(['currentCluster']),
+
+    fields() {
+      const defn = this.definition?.properties || {};
+      const res = [];
+
+      Object.keys(defn).forEach((k) => {
+        res.push({
+          name: k,
+          ...defn[k]
+        });
+      });
+
+      return res;
+    }
+   },
+
+  methods: {
+    async load() {
+
+      console.log(this);
+      const data = await this.$store.dispatch(
+        `cluster/request`,
+        { url: `/k8s/clusters/${ this.currentCluster.id }/api/openapi/v2?timeout=32s` }
+      );
+
+      console.log(data);
+    },
+
+    expand(field) {
+      console.log('expand ' + field)
+      //this.expanded[field] = !this.expanded[field];
+
+      console.log(this.expanded[field]);
+
+      this.$set(this.expanded, field, !this.expanded[field]);
+    }
+  }
+};
+</script>
+
+<template>
+  <div v-if="definition" class="main">
+    <div class="title">
+      Description
+    </div>
+    <div v-if="definition.description">{{ definition.description }}</div>
+    <div v-else>No Description</div>
+    <div
+      v-if="fields.length"
+      class="title"
+    >
+      Fields
+    </div>
+    <div v-for="field in fields" :key="field.name">
+      <div class="field-section">
+        <div class="field">
+          {{ field.name }}
+          <a
+            v-if="field.$moreInfo"
+            :href="field.$moreInfo"
+            target="_blank"
+            class="field-link"
+          >
+            <i class="icon icon-external-link" />
+          </a>
+        </div>
+          <div v-if="field.type" class="field-type">
+            <div>{{ field.type }}</div>
+          </div>
+          <div v-else>
+            <div v-if="field.$refName" class="field-type field-expander" @click="expand(field.name)">{{ field.$refNameShort }} <i class="icon icon-sort" /></div>
+            <div v-else class="field-type">Object</div>
+          </div>
+        </div>
+        <div class="ml-20">
+          <!-- <div class="field-description">{{ field.description }}</div> -->
+          <Markdown
+            v-if="field.description"
+            v-model="field.description"
+          />
+          <!-- <Description
+            v-if="field.description"
+            v-model="field.description"
+          /> -->
+        <div
+          v-if="expanded[field.name]"
+          class="sub-name ml-20"
+        >
+          {{ field.$refName }}
+        </div>
+        <ExplainPanel
+          v-if="expanded[field.name]"
+          :definition="field.$$ref"
+          class="embedded ml-20"
+        />
+      </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .main {
+    // margin: 0 10px 10px 10px;
+    overflow: scroll;
+  }
+
+  .embedded {
+    // border-left: 2px solid var(--box-bg);
+    border-bottom: 2px solid var(--primary);
+    border: 2px solid var(--primary);
+    padding-left: 10px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sub-name {
+    // background-color: var(--box-bg);
+    background-color: var(--primary);
+    color: var(--primary-text);
+    padding: 4px;
+    margin-top: 10px;
+  }
+
+  .title {
+    text-transform: uppercase;
+    margin: 10px 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    padding: 4px 0;
+  }
+
+  .field-section {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-top: 10px; 
+
+    .field {
+      margin-right: 20px;
+    }
+  }
+
+  .field-description {
+    line-height: 1.25;
+    white-space: pre-wrap;
+  }
+
+  .field {
+    margin: 5px 0;
+    font-weight: bold;
+    min-width: 100px; // Attempt type name alignment in general case
+  }
+
+  .field-type {
+    border: 1px solid var(--border);
+    padding: 1px 5px;
+    border-radius: 5px;
+    opacity: 0.85;
+  }
+
+  .field-link {
+    margin-left: 10px;
+
+    I {
+      font-size: 12px;
+      width: 12px;
+      height: 12px;
+    }
+  }
+
+  .field-expander {
+    align-items: center;
+    display: flex;
+
+    > i {
+      font-size: 12px;
+      padding-left: 4px;
+    }
+
+    &:hover {
+      border-color: var(--link);
+      background-color: var(--link);
+      color: var(--link-text);
+      cursor: pointer;
+    }
+  }
+</style>
+<style lang="scss" scoped>
+  .markdown {
+    ::v-deep {
+      P {
+        line-height: 1.25;
+        margin-bottom: 10px;
+      }
+
+      LI:not(:last-child) {
+        margin-bottom: 10px;
+      }
+
+      code {
+        font-size: 12.5px;
+        line-height: normal;
+        padding: 0;
+      }
+    }
+  }
+</style>

--- a/pkg/kubectl-explain/ExplainPanel.vue
+++ b/pkg/kubectl-explain/ExplainPanel.vue
@@ -68,6 +68,12 @@ export default {
   methods: {
     expand(field) {
       this.$set(this.expanded, field, !this.expanded[field]);
+    },
+    navigate(breadcrumbs) {
+      this.$emit('navigate', breadcrumbs);
+    },
+    goto(field) {
+      this.$emit('navigate', field.$breadcrumbs);
     }
   }
 };
@@ -120,15 +126,16 @@ export default {
           /> -->
         <div
           v-if="expanded[field.name]"
-          class="sub-name ml-20"
+          class="sub-name"
         >
-          {{ field.$refName }}
+          <a href="#" class="sub-type-link" @click="goto(field)">{{ field.$refName }}</a>
         </div>
         <ExplainPanel
           v-if="expanded[field.name]"
           :expand-all="expandAll"
           :definition="field.$$ref"
-          class="embedded ml-20"
+          class="embedded"
+          @navigate="navigate"
         />
       </div>
       </div>
@@ -162,9 +169,10 @@ export default {
   .title {
     text-transform: uppercase;
     margin: 10px 0;
+    background-color: var(--primary-light-bg);
     border-top: 1px solid var(--border);
     border-bottom: 1px solid var(--border);
-    padding: 4px 0;
+    padding: 6px 0;
   }
 
   .field-section {
@@ -193,6 +201,10 @@ export default {
   .field-type-panel {
     align-items: center;
     display: flex;
+  }
+
+  .sub-type-link {
+    color: var(--primary-text);
   }
 
   .field-type {

--- a/pkg/kubectl-explain/ExplainPanel.vue
+++ b/pkg/kubectl-explain/ExplainPanel.vue
@@ -28,7 +28,7 @@ export default {
   mounted() {
     if (this.expandAll) {
       this.fields.forEach((field) => {
-        if (field.$ref) {
+        if (field.$$ref) {
           this.$set(this.expanded, field.name, this.expandAll);
         }
       });
@@ -39,7 +39,7 @@ export default {
     expandAll(neu, old) {
       if (neu !== old) {
         this.fields.forEach((field) => {
-          if (field.$ref) {
+          if (field.$$ref) {
             this.$set(this.expanded, field.name, neu);
           }
         });

--- a/pkg/kubectl-explain/ExplainPanel.vue
+++ b/pkg/kubectl-explain/ExplainPanel.vue
@@ -51,13 +51,13 @@ export default {
     ...mapGetters(['currentCluster']),
 
     fields() {
-      const defn = this.definition?.properties || {};
+      const definition = this.definition?.properties || {};
       const res = [];
 
-      Object.keys(defn).forEach((k) => {
+      Object.keys(definition).forEach((k) => {
         res.push({
           name: k,
-          ...defn[k]
+          ...definition[k]
         });
       });
 
@@ -81,9 +81,10 @@ export default {
 
 <template>
   <div v-if="definition" class="main">
-    <div class="title">
+    <!-- <div class="title">
       Description
-    </div>
+    </div> -->
+    <div class="title-spacer" />
     <div v-if="definition.description">{{ definition.description }}</div>
     <div v-else>No Description</div>
     <div
@@ -110,7 +111,16 @@ export default {
           </div>
           <div v-else class="field-type-panel">
             <span v-if="field.type === 'array'" class="mr-5">[]</span>
-            <div v-if="field.$refName" class="field-type field-expander" @click="expand(field.name)">{{ field.$refNameShort }} <i class="icon icon-sort" /></div>
+            <div v-if="field.$refName" class="field-type field-expander" @click="expand(field.name)">{{ field.$refNameShort }} 
+              <i
+                v-if="!expanded[field.name]"
+                class="icon icon-chevron-down"
+              />
+              <i
+                v-else
+                class="icon icon-chevron-up"
+              />
+            </div>
             <div v-else class="field-type">Object</div>
           </div>
         </div>
@@ -129,6 +139,9 @@ export default {
           class="sub-name"
         >
           <a href="#" class="sub-type-link" @click="goto(field)">{{ field.$refName }}</a>
+          <a href="#" class="sub-type-link" @click="goto(field)">
+            <i class="sub-name-goto icon icon-upload" />
+          </a>
         </div>
         <ExplainPanel
           v-if="expanded[field.name]"
@@ -145,25 +158,42 @@ export default {
 
 <style lang="scss" scoped>
   .main {
-    // margin: 0 10px 10px 10px;
     overflow: scroll;
   }
 
   .embedded {
-    // border-left: 2px solid var(--box-bg);
     border-bottom: 2px solid var(--primary);
     border: 2px solid var(--primary);
     padding-left: 10px;
     display: flex;
     flex-direction: column;
+
+    .title-spacer {
+      margin-top: 10px;
+    }
   }
 
   .sub-name {
-    // background-color: var(--box-bg);
     background-color: var(--primary);
     color: var(--primary-text);
     padding: 4px;
     margin-top: 10px;
+    display: flex;
+
+    :first-child {
+      flex: 1;
+    }
+
+    .sub-type-link {
+      color: var(--primary-text);
+      display: flex;
+    }
+
+    .sub-name-goto {
+      flex: 0;
+      font-size: 16px;
+      padding-right: 2px;
+    }
   }
 
   .title {
@@ -203,10 +233,6 @@ export default {
     display: flex;
   }
 
-  .sub-type-link {
-    color: var(--primary-text);
-  }
-
   .field-type {
     border: 1px solid var(--border);
     padding: 1px 5px;
@@ -230,8 +256,8 @@ export default {
     user-select: none;
 
     > i {
-      font-size: 12px;
-      padding-left: 4px;
+      font-size: 14px;
+      padding-left: 8px;
     }
 
     &:hover {

--- a/pkg/kubectl-explain/SlideInPanel.vue
+++ b/pkg/kubectl-explain/SlideInPanel.vue
@@ -29,6 +29,7 @@ export default {
       resizeLeft: '',
       resizePosition: 'absolute',
       width: '33%',
+      right: '-33%',
     };
   },
 
@@ -44,11 +45,13 @@ export default {
     open() {
       this.isOpen = true;
       this.addCloseKeyHandler();
+      this.right = '0';
     },
 
     close() {
       this.isOpen = false;
       this.removeCloseKeyHandler();
+      this.right = `-${ this.width }`;
     },
 
     scrollTop() {
@@ -211,7 +214,7 @@ export default {
 </script>
 
 <template>
-  <div class="slide-in" :class="{ 'slide-in-open': isOpen }" :style="{ width }">
+  <div class="slide-in" :class="{ 'slide-in-open': isOpen }" :style="{ width, right }">
     <div class="panel-resizer"
       ref="resizer"
       v-bind:style="{ position: resizePosition, left: resizeLeft }"
@@ -268,7 +271,9 @@ export default {
 
   .main-panel {
     padding-left: 4px;
-
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
   }
 
   .header {

--- a/pkg/kubectl-explain/SlideInPanel.vue
+++ b/pkg/kubectl-explain/SlideInPanel.vue
@@ -21,18 +21,18 @@ export default {
 
   data() {
     return {
-      isOpen: false,
-      definition: undefined,
-      busy: true,
-      expandAll: false,
-      isResizing: false,
-      resizeLeft: '',
+      isOpen:         false,
+      definition:     undefined,
+      busy:           true,
+      expandAll:      false,
+      isResizing:     false,
+      resizeLeft:     '',
       resizePosition: 'absolute',
-      width: '33%',
-      right: '-33%',
-      breadcrumbs: undefined,
-      definitions: {},
-      noResource: false,
+      width:          '33%',
+      right:          '-33%',
+      breadcrumbs:    undefined,
+      definitions:    {},
+      noResource:     false,
     };
   },
 
@@ -101,11 +101,11 @@ export default {
     expand(definitions, definition, breadcrumbs = []) {
       Object.keys(definition?.properties || {}).forEach((propName) => {
         const prop = definition.properties[propName];
-        const propRef = prop.$ref || prop.items?.$ref; 
+        const propRef = prop.$ref || prop.items?.$ref;
 
         if (propRef && propRef.startsWith('#/definitions/')) {
           const p = propRef.split('/');
-          const id = p[p.length -1 ];
+          const id = p[p.length - 1];
 
           const ref = definitions[id];
 
@@ -123,7 +123,7 @@ export default {
 
             this.expand(definitions, ref, prop.$breadcrumbs);
           } else {
-            console.warn('Can not find definition for ' + id); // eslint-disable-line no-console
+            console.warn(`Can not find definition for ${ id }`); // eslint-disable-line no-console
           }
         }
 
@@ -139,7 +139,6 @@ export default {
       this.noResource = false;
 
       if (response.error) {
-        console.error(response.error);
         this.busy = false;
 
         return;
@@ -150,8 +149,6 @@ export default {
       if (!data) {
         return;
       }
-
-
 
       const schema = response.schema;
 
@@ -172,14 +169,12 @@ export default {
           group = group.split('.').reverse().join('.');
         }
 
-        const name = `${ group }.${ schema.attributes.version}.${ schema.attributes.kind}`;
+        const name = `${ group }.${ schema.attributes.version }.${ schema.attributes.kind }`;
         const defn = data.definitions[name];
 
         this.definitions = data.definitions;
 
         this.expand(data.definitions, defn, [name]);
-
-        // console.log(JSON.parse(JSON.stringify(defn, null, 2)));
 
         this.definition = defn;
       } else {
@@ -191,12 +186,11 @@ export default {
     startPanelResize(ev) {
       this.isResizing = true;
       this.$refs.resizer.setPointerCapture(ev.pointerId);
-
     },
     doPanelResize(ev) {
       if (this.isResizing) {
         this.resizePosition = 'fixed';
-        this.resizeLeft = ev.clientX + 'px';
+        this.resizeLeft = `${ ev.clientX }px`;
       }
     },
     endPanelResize(ev) {
@@ -225,7 +219,6 @@ export default {
         };
       });
 
-
       // this.expand(this.definitions, defn, [goto]);
       this.expand(this.definitions, defn, breadcrumbs);
 
@@ -251,7 +244,7 @@ export default {
         }
       }
 
-       this.navigate(breadcrumbs.map(b => b.id));
+      this.navigate(breadcrumbs.map(b => b.id));
     }
   },
 };
@@ -259,10 +252,18 @@ export default {
 
 <template>
   <div>
-    <div class="slide-in-glass" :class="{ 'slide-in-glass-open': isOpen }" @click="close()"></div>
-    <div class="slide-in" :class="{ 'slide-in-open': isOpen }" :style="{ width, right }">
-      <div class="panel-resizer"
+    <div
+      class="slide-in-glass"
+      :class="{ 'slide-in-glass-open': isOpen }"
+      @click="close()" />
+    <div
+      class="slide-in"
+      :class="{ 'slide-in-open': isOpen }"
+      :style="{ width, right }"
+    >
+      <div
         ref="resizer"
+        class="panel-resizer"
         v-bind:style="{ position: resizePosition, left: resizeLeft }"
         @pointerdown="startPanelResize"
         @pointermove="doPanelResize"
@@ -271,10 +272,23 @@ export default {
       <div class="main-panel">
         <!-- <div class="glass" /> -->
         <div class="header">
-          <div v-if="breadcrumbs" class="breadcrumbs">
-            <div v-for="(b, i) in breadcrumbs" :key="b.id">
-              <span v-if="i > 0" class="ml-5 mr-5">&gt;</span>
-              <a href="#" class="breadcrumb-link" @click="goto(b.id)">{{ b.name }}</a>
+          <div
+            v-if="breadcrumbs"
+            class="breadcrumbs"
+          >
+            <div
+              v-for="(b, i) in breadcrumbs"
+              :key="b.id"
+            >
+              <span
+                v-if="i > 0"
+                class="ml-5 mr-5"
+              >&gt;</span>
+              <a
+                href="#"
+                class="breadcrumb-link"
+                @click="goto(b.id)"
+              >{{ b.name }}</a>
             </div>
           </div>
           <div v-else @click="scrollTop()">{{ title }}</div>
@@ -307,7 +321,7 @@ export default {
           v-if="noResource"
           class="select-resource"
         >
-          <img src="./explain.svg" />
+          <img src="./explain.svg">
           <div>
             Select a Kubernetes resource to get the resource explanation
           </div>
@@ -411,7 +425,7 @@ export default {
     display: flex;
     flex-direction: column;
     position: fixed;
-    top: 0; 
+    top: 0;
     z-index: 2000;
     top: $header-height;
     height: calc(100vh - $header-height);

--- a/pkg/kubectl-explain/SlideInPanel.vue
+++ b/pkg/kubectl-explain/SlideInPanel.vue
@@ -25,6 +25,10 @@ export default {
       definition: undefined,
       busy: true,
       expandAll: false,
+      isResizing: false,
+      resizeLeft: '',
+      resizePosition: 'absolute',
+      width: '33%',
     };
   },
 
@@ -177,46 +181,95 @@ export default {
       }
 
       this.busy = false;
-    }
+    },
+    startPanelResize(ev) {
+      console.log('startPanelResize');
+      console.log(ev);
+      this.isResizing = true;
+      this.$refs.resizer.setPointerCapture(ev.pointerId);
+
+    },
+    doPanelResize(ev) {
+      if (this.isResizing) {
+        this.resizePosition = 'fixed';
+        this.resizeLeft = ev.clientX + 'px';
+      }
+    },
+    endPanelResize(ev) {
+      this.isResizing = false;
+      this.$refs.resizer.releasePointerCapture(ev.pointerId);
+
+      const width = window.innerWidth - ev.clientX + 2;
+
+      this.resizePosition = 'absolute';
+      this.resizeLeft = '';
+
+      this.width = `${ width }px`;
+    },
   },
 };
 </script>
 
 <template>
-  <div class="slide-in" :class="{ 'slide-in-open': isOpen }">
-    <!-- <div class="glass" /> -->
-    <div class="header">
-      <div @click="scrollTop()">{{ title }}</div>
-      <i
-        v-if="!busy"
-        class="icon icon-sort mr-10"
-        @click="toggleAll()"
-      />
-      <i
-        class="icon icon-close"
-        @click="close"
-      />
-    </div>
-    <div v-if="busy"
-      class="loading"
-    >
-      <div>
-        <i class="icon icon-lg icon-spinner icon-spin" />
-      </div>
-    </div>
-    <ExplainPanel
-      ref="main"
-      :expand-all="expandAll"
-      v-if="definition"
-      :definition="definition"
-      class="explain-panel"
+  <div class="slide-in" :class="{ 'slide-in-open': isOpen }" :style="{ width }">
+    <div class="panel-resizer"
+      ref="resizer"
+      v-bind:style="{ position: resizePosition, left: resizeLeft }"
+      @pointerdown="startPanelResize"
+      @pointermove="doPanelResize"
+      @pointerup="endPanelResize"
     />
+    <div class="main-panel">
+      <!-- <div class="glass" /> -->
+      <div class="header">
+        <div @click="scrollTop()">{{ title }}</div>
+        <i
+          v-if="!busy"
+          class="icon icon-sort mr-10"
+          @click="toggleAll()"
+        />
+        <i
+          class="icon icon-close"
+          @click="close"
+        />
+      </div>
+      <div v-if="busy"
+        class="loading"
+      >
+        <div>
+          <i class="icon icon-lg icon-spinner icon-spin" />
+        </div>
+      </div>
+      <ExplainPanel
+        ref="main"
+        :expand-all="expandAll"
+        v-if="definition"
+        :definition="definition"
+        class="explain-panel"
+      />
+    </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
   $header-height: 55px;
   $slidein-width: 33%;
+
+  .panel-resizer {
+    position: absolute;
+    height: 100%;
+    border: 2px solid transparent;
+
+    &:hover {
+      border: 2px solid var(--primary);
+      cursor: col-resize;
+    }
+  }
+
+  .main-panel {
+    padding-left: 4px;
+
+  }
 
   .header {
     align-items: center;

--- a/pkg/kubectl-explain/SlideInPanel.vue
+++ b/pkg/kubectl-explain/SlideInPanel.vue
@@ -1,0 +1,281 @@
+<script>
+import ExplainPanel from './ExplainPanel';
+
+// Regex for more info in descriptions
+const MORE_INFO_REGEX = /More info:\s*(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*))/;
+
+export default {
+  components: { ExplainPanel },
+
+  props: {
+    typeName: {
+      type:    String,
+      default: ''
+    },
+    schema: {
+      type:    Object,
+      default: () => {}
+    },
+  },
+
+  data() {
+    return {
+      isOpen: false,
+      definition: undefined,
+      busy: true,
+    };
+  },
+
+  computed: {
+    title() {
+      console.log(this.schema);
+
+      return this.schema?.attributes?.kind || 'Loading ...';
+    }
+  },
+
+  methods: {
+    open(typeName) {
+
+      console.log('open');
+
+      console.log(this);
+      console.log(this.typeName);
+      console.log(typeName);
+      console.log(this.schema);
+
+      console.log(this.$dispatch);
+
+      this.isOpen = true;
+    },
+
+    close() {
+      console.log('close');
+
+      this.isOpen = false;
+    },
+
+    scrollTop() {
+      //this.$refs.main.scrollTo(0,0);
+
+      this.$refs.main.$el.scrollTop = 0;
+    },
+
+    extractMoreInfo(property) {
+      const description = property.description || '';
+      const found = description.match(MORE_INFO_REGEX);
+
+      if (found?.length > 0) {
+        let url = found[0];
+        const updated = description.replace(url, '').trim();
+        const index = url.indexOf('http');
+
+        url = url.substr(index);
+
+        if (url.endsWith('.')) {
+          url = url.substr(0, url.length - 1);
+        }
+
+        property.$moreInfo = url;
+        property.description = updated;
+      }
+    },
+
+    parse(property) {
+      this.extractMoreInfo(property);
+
+      // Object.values(property.properties || {}).forEach((v) => {
+      //   this.extractMoreInfo(v);
+
+      //   // if (v.$ref) {
+      //   //   this.parse(v.$ref);
+      //   // }
+      // });
+    },
+
+    expand(definitions, definition) {
+      Object.keys(definition?.properties || {}).forEach((propName) => {
+        const prop = definition.properties[propName];
+
+        if (prop.$ref && prop.$ref.startsWith('#/definitions/')) {
+          const p = prop.$ref.split('/');
+          const id = p[p.length -1 ];
+
+          const ref = definitions[id];
+
+          if (ref) {
+            prop.$$ref = ref;
+            prop.$refName = id;
+
+            const parts = prop.$refName.split('.');
+
+            console.log(parts);
+
+            prop.$refNameShort = parts[parts.length - 1];
+
+            this.expand(definitions, ref);
+          } else {
+            console.warn('Can not find definition for ' + id);
+          }
+        }
+
+        this.parse(prop);
+      });
+    },
+
+    update(response) {
+      if (response.error) {
+        console.error(response.error);
+        this.busy = false;
+
+        return;
+      }
+
+      const data = response.data;
+
+      if (!data) {
+        return;
+      }
+
+      const schema = response.schema;
+
+      console.error(schema);
+
+      if (schema?.attributes) {
+        let group = schema.attributes.group || 'core';
+
+        if (!group.includes('.')) {
+          group = `io.k8s.api.${ group }`;
+        } else {
+          // Reverse the group
+          group = group.split('.').reverse().join('.');
+        }
+
+        const name = `${ group }.${ schema.attributes.version}.${ schema.attributes.kind}`;
+        console.log(data);
+        const defn = data.definitions[name];
+
+        console.log('>>>>>>>>>>>>>>>>>>>>>>>');
+        console.log(name);
+
+        //Object.keys(data.definitions).forEach((key) => console.log(key));
+
+        Object.keys(data.definitions).forEach((key) => {
+          if (key.includes(schema.attributes.kind)) {
+            console.log(key);
+          }
+        });
+
+        console.log(defn);
+
+        this.expand(data.definitions, defn);
+
+        console.log(JSON.parse(JSON.stringify(defn, null, 2)));
+
+        this.definition = defn;
+      } else {
+        this.definition = undefined;
+      }
+
+      this.busy = false;
+    }
+  },
+};
+</script>
+
+<template>
+  <div class="slide-in" :class="{ 'slide-in-open': isOpen }">
+    <!-- <div class="glass" /> -->
+    <div class="header">
+      <div @click="scrollTop()">{{ title }}</div>
+      <i
+        class="icon icon-close"
+        @click="close"
+      />
+    </div>
+    <div v-if="busy"
+      class="loading"
+    >
+      <div>
+        <i class="icon icon-lg icon-spinner icon-spin" />
+      </div>
+    </div>
+    <ExplainPanel
+      ref="main"
+      v-if="definition"
+      :definition="definition"
+      class="explain-panel"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  $header-height: 55px;
+  $slidein-width: 33%;
+
+  .header {
+    align-items: center;
+    display: flex;
+    padding: 4px;
+    border-bottom: 1px solid var(--border);
+
+    > :first-child {
+      flex: 1;
+      font-weight: bold;
+    }
+
+    > i {
+      padding: 8px;
+      opacity: 0.7;
+
+      &:hover {
+        background-color: var(--primary);
+        color: var(--primary-text);
+        cursor: pointer;
+        opacity: 1;
+      }
+    }
+  }
+
+  .loading {
+    align-items: center;
+    display: flex;
+    flex: 1;
+    justify-content: center;
+
+    .icon-spinner {
+      font-size: 24px;
+    }
+  }
+
+  .glass {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+  }
+
+  .slide-in {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0; 
+    z-index: 2000;
+    top: $header-height;
+    height: calc(100vh - $header-height);
+    width: $slidein-width;
+    background-color: #fff;
+    right: -$slidein-width;
+    transition: right 0.5s;
+    border-left: 1px solid var(--border);
+  }
+
+  .slide-in-open {
+    right: 0;
+  }
+
+  .explain-panel {
+    padding: 10px;
+  }
+</style>

--- a/pkg/kubectl-explain/SlideInPanel.vue
+++ b/pkg/kubectl-explain/SlideInPanel.vue
@@ -173,6 +173,10 @@ export default {
         const defn = data.definitions[name];
 
         this.definitions = data.definitions;
+        this.expanded = {};
+
+        // this.breadcrumbs = [name];
+        // this.expandAll = false;
 
         this.expand(data.definitions, defn, [name]);
 
@@ -303,7 +307,7 @@ export default {
           />
         </div>
         <div v-if="busy"
-          class="loading"
+          class="loading panel-loading"
         >
           <div>
             <i class="icon icon-lg icon-spinner icon-spin" />
@@ -458,5 +462,9 @@ export default {
       opacity: 0.5;
       z-index: 1000;
     }
+  }
+
+  .panel-loading {
+    margin-top: 20px;
   }
 </style>

--- a/pkg/kubectl-explain/babel.config.js
+++ b/pkg/kubectl-explain/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./.shell/pkg/babel.config.js');

--- a/pkg/kubectl-explain/explain.svg
+++ b/pkg/kubectl-explain/explain.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M20 20h4c.553 0 1-.445 1-.995V1.995C25 1.45 24.552 1 24 1H2c-.553 0-1 .445-1 .995v17.01c0 .544.448.995 1 .995h12.167l5.07 4.346c.425.365.763.21.763-.337V20z" stroke="#474747" stroke-width="2"/>
+        <path d="M6 7h13v1H6zm0 3h13v1H6zm0 3h9v1H6z" fill="#575757"/>
+    </g>
+</svg>

--- a/pkg/kubectl-explain/explain.svg
+++ b/pkg/kubectl-explain/explain.svg
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
 <svg width="800px" height="800px" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fill-rule="evenodd">
-        <path d="M20 20h4c.553 0 1-.445 1-.995V1.995C25 1.45 24.552 1 24 1H2c-.553 0-1 .445-1 .995v17.01c0 .544.448.995 1 .995h12.167l5.07 4.346c.425.365.763.21.763-.337V20z" stroke="#474747" stroke-width="2"/>
-        <path d="M6 7h13v1H6zm0 3h13v1H6zm0 3h9v1H6z" fill="#575757"/>
+        <path d="M20 20h4c.553 0 1-.445 1-.995V1.995C25 1.45 24.552 1 24 1H2c-.553 0-1 .445-1 .995v17.01c0 .544.448.995 1 .995h12.167l5.07 4.346c.425.365.763.21.763-.337V20z" stroke="#000" stroke-width="2"/>
+        <path d="M6 7h13v1H6zm0 3h13v1H6zm0 3h9v1H6z" fill="#000"/>
     </g>
 </svg>

--- a/pkg/kubectl-explain/explain.svg
+++ b/pkg/kubectl-explain/explain.svg
@@ -1,9 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg width="800px" height="800px" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">
-    <g fill="none" fill-rule="evenodd">
-        <path d="M20 20h4c.553 0 1-.445 1-.995V1.995C25 1.45 24.552 1 24 1H2c-.553 0-1 .445-1 .995v17.01c0 .544.448.995 1 .995h12.167l5.07 4.346c.425.365.763.21.763-.337V20z" stroke="#000" stroke-width="2"/>
-        <path d="M6 7h13v1H6zm0 3h13v1H6zm0 3h9v1H6z" fill="#000"/>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24">
+    <path d="M260-320q47 0 91.5 10.5T440-278v-394q-41-24-87-36t-93-12q-36 0-71.5 7T120-692v396q35-12 69.5-18t70.5-6Zm260 42q44-21 88.5-31.5T700-320q36 0 70.5 6t69.5 18v-396q-33-14-68.5-21t-71.5-7q-47 0-93 12t-87 36v394Zm-40 118q-48-38-104-59t-116-21q-42 0-82.5 11T100-198q-21 11-40.5-1T40-234v-482q0-11 5.5-21T62-752q46-24 96-36t102-12q58 0 113.5 15T480-740q51-30 106.5-45T700-800q52 0 102 12t96 36q11 5 16.5 15t5.5 21v482q0 23-19.5 35t-40.5 1q-37-20-77.5-31T700-240q-60 0-116 21t-104 59ZM280-494Z"/>
 </svg>

--- a/pkg/kubectl-explain/index.ts
+++ b/pkg/kubectl-explain/index.ts
@@ -1,6 +1,6 @@
 import { importTypes } from '@rancher/auto-import';
 import { ActionLocation, IPlugin } from '@shell/core/types';
-import { install } from './slide-in';
+import { explain } from './slide-in';
 
 // Init the package
 export default function(plugin: IPlugin, internal: any) {
@@ -10,18 +10,13 @@ export default function(plugin: IPlugin, internal: any) {
   // Provide plugin metadata from package.json
   plugin.metadata = require('./package.json');
 
-  // Load a product
-  // plugin.addProduct(require('./product'));
-
   const store = internal.store;
-
-  console.log(internal);
 
   plugin.addAction(ActionLocation.HEADER, { product: ['explorer'] }, {
     label: 'Explain ...',
     svg: require('./explain.svg'),
     invoke: (opts, res, globals) => {
-      install(store, globals.$route);
+      explain(store, globals.$route);
     }
   });
 }

--- a/pkg/kubectl-explain/index.ts
+++ b/pkg/kubectl-explain/index.ts
@@ -3,7 +3,7 @@ import { ActionLocation, IPlugin } from '@shell/core/types';
 import { explain } from './slide-in';
 
 // Init the package
-export default function(plugin: IPlugin, internal: any) {
+export default function(plugin: IPlugin, internal: any): void {
   // Auto-import model, detail, edit from the folders
   importTypes(plugin);
 
@@ -13,8 +13,8 @@ export default function(plugin: IPlugin, internal: any) {
   const store = internal.store;
 
   plugin.addAction(ActionLocation.HEADER, { product: ['explorer'] }, {
-    label: 'Explain ...',
-    svg: require('./explain.svg'),
+    label:  'Explain ...',
+    svg:    require('./explain.svg'),
     invoke: (opts, res, globals) => {
       explain(store, globals.$route);
     }

--- a/pkg/kubectl-explain/index.ts
+++ b/pkg/kubectl-explain/index.ts
@@ -1,0 +1,27 @@
+import { importTypes } from '@rancher/auto-import';
+import { ActionLocation, IPlugin } from '@shell/core/types';
+import { install } from './slide-in';
+
+// Init the package
+export default function(plugin: IPlugin, internal: any) {
+  // Auto-import model, detail, edit from the folders
+  importTypes(plugin);
+
+  // Provide plugin metadata from package.json
+  plugin.metadata = require('./package.json');
+
+  // Load a product
+  // plugin.addProduct(require('./product'));
+
+  const store = internal.store;
+
+  console.log(internal);
+
+  plugin.addAction(ActionLocation.HEADER, { product: ['explorer'] }, {
+    label: 'Explain ...',
+    svg: require('./explain.svg'),
+    invoke: (opts, res, globals) => {
+      install(store, globals.$route);
+    }
+  });
+}

--- a/pkg/kubectl-explain/l10n/en-us.yaml
+++ b/pkg/kubectl-explain/l10n/en-us.yaml
@@ -1,0 +1,3 @@
+kubectl-explain:
+  title: Kubernetes Explain
+  prompt: Select a Kubernetes resource to get the resource explanation

--- a/pkg/kubectl-explain/package.json
+++ b/pkg/kubectl-explain/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "kubectl-explain",
+  "description": "kubectl-explain plugin",
+  "version": "0.1.0",
+  "private": false,
+  "rancher": true,
+  "scripts": {
+    "dev": "./node_modules/.bin/nuxt dev",
+    "nuxt": "./node_modules/.bin/nuxt"
+  },
+  "engines": {
+    "node": ">=12"
+  },
+  "devDependencies": {
+    "@vue/cli-plugin-babel": "4.5.18",
+    "@vue/cli-service": "4.5.18",
+    "@vue/cli-plugin-typescript": "4.5.18"
+  },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "not dead"
+  ]
+}

--- a/pkg/kubectl-explain/package.json
+++ b/pkg/kubectl-explain/package.json
@@ -3,7 +3,9 @@
   "description": "kubectl-explain plugin",
   "version": "0.1.0",
   "private": false,
-  "rancher": true,
+  "rancher": {
+    "catalog.cattle.io/ui-hidden-builtin": true
+  },
   "scripts": {
     "dev": "./node_modules/.bin/nuxt dev",
     "nuxt": "./node_modules/.bin/nuxt"

--- a/pkg/kubectl-explain/slide-in.js
+++ b/pkg/kubectl-explain/slide-in.js
@@ -53,15 +53,9 @@ export async function install(store, route) {
       }
     });
 
-    console.error('OPEN');
-    console.log(schema);
-    console.log(typeName);
-
     var div = document.createElement('div');
     div.id = 'kubectl-explain';
     document.body.appendChild(div);
-
-    console.log(component);
 
     component.$mount('#kubectl-explain');
 
@@ -70,8 +64,6 @@ export async function install(store, route) {
 
     setTimeout(() => component.open(typeName), 0);
   } else {
-    console.log(component);
-
     component.busy = true;
     component.typeName = typeName;
     component.schema = schema;

--- a/pkg/kubectl-explain/slide-in.js
+++ b/pkg/kubectl-explain/slide-in.js
@@ -2,7 +2,10 @@ import Vue from 'vue';
 
 import Panel from './SlideInPanel';
 
-let component;
+const PANEL_ID = 'kubectl-explain';
+
+// Slide in panel component
+let slideInPanel;
 
 let openAPIData;
 let cluster;
@@ -15,21 +18,20 @@ function loadOpenAPIData(store, schema) {
       { url: `/k8s/clusters/${ cluster.id }/openapi/v2?timeout=32s` }
     ).then((response) => {
       openAPIData = response.data || response;
-      component.update( { data: openAPIData, schema });
+      slideInPanel.update( { data: openAPIData, schema });
     }).catch((e) => {
       openAPIData = undefined;
-      component.update({ error: e });
+      slideInPanel.update({ error: e });
     });
   } else {
-    component.update({ data: openAPIData, schema });
+    slideInPanel.update({ data: openAPIData, schema });
   }
 }
 
 /**
- * Show the explain panel
+ * Show the slide-in panel with the resource explanation
  */
 export async function explain(store, route) {
-  // Get params
   cluster = store.getters['currentCluster'];
   const typeName = route.params?.resource;
   const schema = typeName ? store.getters[`cluster/schemaFor`](typeName) : undefined;
@@ -38,33 +40,33 @@ export async function explain(store, route) {
   console.log(route);
   console.log(typeName);
 
-  if (!component) {
-    component = new Vue(Panel, {
-      props: {
-        $dispatch: store.dispatch,
-        typeName,
-        schema,
-        busy:      true,
-      }
-    });
+  // Create slide-in panel, if this is the first-time it is being shown
+  if (!slideInPanel) {
+    const slideInPanelClass = Vue.extend(Panel);
 
+    slideInPanel = new slideInPanelClass();
+
+    // Create a DIV that we can mount the slide-in panel component into
     const div = document.createElement('div');
 
-    div.id = 'kubectl-explain';
+    div.id = PANEL_ID;
     document.body.appendChild(div);
 
-    component.$mount('#kubectl-explain');
-
-    component.typeName = typeName;
-    component.schema = schema;
-
-    setTimeout(() => component.open(typeName), 0);
-  } else {
-    component.busy = true;
-    component.typeName = typeName;
-    component.schema = schema;
-    component.open(typeName);
+    slideInPanel.$mount(`#${ PANEL_ID }`);
   }
 
-  loadOpenAPIData(store, schema);
+  // Open the slide-in panel
+  const title = store.getters['i18n/t']('kubectl-explain.title');
+
+  slideInPanel.busy = true;
+  slideInPanel.typeName = typeName;
+  slideInPanel.schema = schema;
+  // slideInPanel.title = title;
+  slideInPanel.$t = store.getters['i18n/t'];
+
+  setTimeout(() => {
+    slideInPanel.open(typeName);
+
+    loadOpenAPIData(store, schema);
+  }, 0);
 }

--- a/pkg/kubectl-explain/slide-in.js
+++ b/pkg/kubectl-explain/slide-in.js
@@ -1,3 +1,5 @@
+import Vue from 'vue';
+
 import Panel from './SlideInPanel';
 
 let component;
@@ -38,11 +40,12 @@ export async function explain(store, route) {
         $dispatch: store.dispatch,
         typeName,
         schema,
-        busy: true,
+        busy:      true,
       }
     });
 
-    var div = document.createElement('div');
+    const div = document.createElement('div');
+
     div.id = 'kubectl-explain';
     document.body.appendChild(div);
 

--- a/pkg/kubectl-explain/slide-in.js
+++ b/pkg/kubectl-explain/slide-in.js
@@ -12,9 +12,7 @@ function loadOpenAPIData(store, schema) {
       `cluster/request`,
       { url: `/k8s/clusters/${ cluster.id }/openapi/v2?timeout=32s` }
     ).then((response) => {
-      console.error('LOADED API DATA');
       openAPIData = response.data || response;
-      console.log(response);
       component.update( { data: openAPIData, schema });
     }).catch((e) => {
       openAPIData = undefined;
@@ -23,21 +21,12 @@ function loadOpenAPIData(store, schema) {
   } else {
     component.update({ data: openAPIData, schema });
   }
-
-  // console.error('Load OPEN API DATA');
-
-  // const sleep = ms => new Promise(r => setTimeout(r, ms));
-
-  // sleep(5000).then(() => { component.busy = false; });
-
-  // console.log(schema);
 }
 
-export async function install(store, route) {
-  console.log('hello');
-  console.log('store');
-  console.log(route);
-
+/**
+ * Show the explain panel
+ */
+export async function explain(store, route) {
   // Get params
   cluster = store.getters['currentCluster'];
   const typeName = route.params?.resource;

--- a/pkg/kubectl-explain/slide-in.js
+++ b/pkg/kubectl-explain/slide-in.js
@@ -1,0 +1,82 @@
+import Panel from './SlideInPanel';
+
+let component;
+
+let openAPIData;
+let cluster;
+
+function loadOpenAPIData(store, schema) {
+  // Have we got cached API data?
+  if (!openAPIData) {
+    store.dispatch(
+      `cluster/request`,
+      { url: `/k8s/clusters/${ cluster.id }/openapi/v2?timeout=32s` }
+    ).then((response) => {
+      console.error('LOADED API DATA');
+      openAPIData = response.data || response;
+      console.log(response);
+      component.update( { data: openAPIData, schema });
+    }).catch((e) => {
+      openAPIData = undefined;
+      component.update({ error: e });
+    });
+  } else {
+    component.update({ data: openAPIData, schema });
+  }
+
+  // console.error('Load OPEN API DATA');
+
+  // const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+  // sleep(5000).then(() => { component.busy = false; });
+
+  // console.log(schema);
+}
+
+export async function install(store, route) {
+  console.log('hello');
+  console.log('store');
+  console.log(route);
+
+  // Get params
+  cluster = store.getters['currentCluster'];
+  const typeName = route.params?.resource;
+  const schema = typeName ? store.getters[`cluster/schemaFor`](typeName) : undefined;
+
+  if (!component) {
+    component = new Vue(Panel, {
+      props: {
+        $dispatch: store.dispatch,
+        typeName,
+        schema,
+        busy: true,
+      }
+    });
+
+    console.error('OPEN');
+    console.log(schema);
+    console.log(typeName);
+
+    var div = document.createElement('div');
+    div.id = 'kubectl-explain';
+    document.body.appendChild(div);
+
+    console.log(component);
+
+    component.$mount('#kubectl-explain');
+
+    component.typeName = typeName;
+    component.schema = schema;
+
+    setTimeout(() => component.open(typeName), 0);
+  } else {
+    console.log(component);
+
+    component.busy = true;
+    component.typeName = typeName;
+    component.schema = schema;
+    component.open(typeName);
+  }
+
+  loadOpenAPIData(store, schema);
+}

--- a/pkg/kubectl-explain/slide-in.js
+++ b/pkg/kubectl-explain/slide-in.js
@@ -34,6 +34,10 @@ export async function explain(store, route) {
   const typeName = route.params?.resource;
   const schema = typeName ? store.getters[`cluster/schemaFor`](typeName) : undefined;
 
+  console.log('EXPLAIN');
+  console.log(route);
+  console.log(typeName);
+
   if (!component) {
     component = new Vue(Panel, {
       props: {

--- a/pkg/kubectl-explain/tsconfig.json
+++ b/pkg/kubectl-explain/tsconfig.json
@@ -1,0 +1,53 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "jsx": "preserve",
+    "importHelpers": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "preserveSymlinks": true,
+    "typeRoots": [
+      "../../node_modules",
+      "../../shell/types"
+    ],
+    "types": [
+      "node",
+      "webpack-env",
+      "@types/node",
+      "@types/jest",
+      "@types/lodash",
+      "rancher",
+      "shell"
+    ],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable",
+      "scripthost"
+    ],
+    "paths": {
+      "@shell/*": [
+        "../../shell/*"
+      ],
+      "@components/*": [
+        "@rancher/components/*"
+      ]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.d.ts",
+    "**/*.tsx",
+    "**/*.vue"
+  ],
+  "exclude": [
+    "../../node_modules"
+  ]
+}

--- a/pkg/kubectl-explain/vue.config.js
+++ b/pkg/kubectl-explain/vue.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./.shell/pkg/vue.config')(__dirname);

--- a/shell/components/Markdown.vue
+++ b/shell/components/Markdown.vue
@@ -39,7 +39,7 @@ export default {
     const renderer = new marked.Renderer();
     const linkRenderer = renderer.link;
 
-    const base = this.$router.resolve(this.$route).href.replace(/#.*$/, '');
+    const base = this.$router ? this.$router.resolve(this.$route).href.replace(/#.*$/, '') : '';
 
     renderer.link = function(href, title, text) {
       let external = true;

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -314,7 +314,7 @@ export default {
       const enabled = action.enabled ? action.enabled.apply(this, [opts]) : true;
 
       if (fn && enabled) {
-        fn.apply(this, [opts, [], { $route: this.$route} ]);
+        fn.apply(this, [opts, [], { $route: this.$route }]);
       }
     },
 

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -314,7 +314,7 @@ export default {
       const enabled = action.enabled ? action.enabled.apply(this, [opts]) : true;
 
       if (fn && enabled) {
-        fn.apply(this, [opts, []]);
+        fn.apply(this, [opts, [], { $route: this.$route} ]);
       }
     },
 

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -36,6 +36,7 @@ export const UI_PLUGIN_CHART_ANNOTATIONS = {
   UI_VERSION:         'catalog.cattle.io/ui-version',
   EXTENSIONS_HOST:    'catalog.cattle.io/ui-extensions-host',
   DISPLAY_NAME:       'catalog.cattle.io/display-name',
+  HIDDEN_BUILTIN:     'catalog.cattle.io/ui-hidden-builtin',
 };
 
 // Extension catalog labels

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -98,7 +98,7 @@ export type Action = {
   icon?: string;
   multiple?: boolean;
   enabled?: (ctx: any) => boolean;
-  invoke: (opts: ActionOpts, resources: any[]) => void | boolean | Promise<boolean>;
+  invoke: (opts: ActionOpts, resources: any[], globals?: any) => void | boolean | Promise<boolean>;
 };
 
 /** Definition of a panel (options that can be passed when defining an extension panel enhancement) */

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -273,7 +273,11 @@ export default {
             builtin:        !!p.builtin,
           };
 
-          all.push(item);
+          // Built-in plugins can chose to be hidden - used where we implement as extensions
+          // but don't want to shows them individually on the extensions page
+          if (!(item.builtin && rancher[UI_PLUGIN_CHART_ANNOTATIONS.HIDDEN_BUILTIN])) {
+            all.push(item);
+          }
         }
       });
 


### PR DESCRIPTION
Adds a slide-in that shows 'kubectl explain' information for a Kubernetes resource - this can be brought in via the new icon in the top-right of the page.

<img width="1636" alt="image" src="https://github.com/nwmac/dashboard/assets/1955897/09fc04d3-2229-4b4a-a77d-b02c19739021">

<img width="1312" alt="image" src="https://github.com/nwmac/dashboard/assets/1955897/05a181f5-d22e-4031-89b2-4d38116e0b49">

Notes:

- Adds an icon to the top-right
- Panel can be resized
- Definitions can be expanded/collapsed
- Definition can be opened - gives a breadcrumb:

<img width="1312" alt="image" src="https://github.com/nwmac/dashboard/assets/1955897/5e464cd1-7eb5-462f-a074-968ca96a9f33">
