### PR TITLE
a11y: Guard empty heading in Setting description

### DIFF
--- a/shell/components/Setting.vue
+++ b/shell/components/Setting.vue
@@ -13,6 +13,10 @@ export default {
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
     ...mapGetters({ options: 'action-menu/optionsArray' }),
+
+    hasDescription() {
+      return !!this.t(`advancedSettings.descriptions.${ this.value.id }`);
+    }
   },
 };
 </script>
@@ -36,7 +40,9 @@ export default {
             class="modified"
           >{{ t('advancedSettings.modified') }}</span>
         </h1>
-        <h2>{{ t(`advancedSettings.descriptions.${value.id}`) }}</h2>
+        <h2 v-if="hasDescription">
+          {{ t(`advancedSettings.descriptions.${value.id}`) }}
+        </h2>
       </div>
       <div
         v-if="value.hasActions"


### PR DESCRIPTION
## Summary

Guards the `<h2>` description element in `Setting.vue` so it is only rendered when its translation key resolves to a non-empty string. This prevents the `empty-heading` a11y violation.

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Test plan
- [ ] `yarn lint`
- [ ] Existing unit tests pass
- [ ] `cypress/e2e/tests/accessibility/shell.spec.ts` no longer reports empty-heading violations on the Settings page
