### PR TITLE
a11y: Add screen-reader header for SortableTable actions column

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6705,6 +6705,7 @@ sortableTable:
   resetFilters: Reset
   add: Add
   tableHeader:
+    actions: Actions
     noFilter: This column cannot be filtered by
     groupBy: Group by
     show: Show

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -361,7 +361,11 @@ export default {
       <th
         v-else-if="rowActions"
         :width="rowActionsWidth"
-      />
+      >
+        <span class="sr-only">
+          {{ t('sortableTable.tableHeader.actions') }}
+        </span>
+      </th>
     </tr>
   </thead>
 </template>


### PR DESCRIPTION
## Summary

The actions column `<th>` in `SortableTable/THead.vue` was empty, so screen readers had no accessible name for it. Adds a visually-hidden "Actions" label and a new translation key `sortableTable.tableHeader.actions`.

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Test plan
- [ ] `yarn lint`
- [ ] Existing unit tests pass
- [ ] `cypress/e2e/tests/accessibility/shell.spec.ts` no longer reports missing accessible name for the Actions column
