### PR TITLE
a11y: Scope HorizontalPanel aria-controls to avoid ID collisions

### DIFF
--- a/shell/components/nav/WindowManager/panels/HorizontalPanel.vue
+++ b/shell/components/nav/WindowManager/panels/HorizontalPanel.vue
@@ -63,7 +63,7 @@ const {
         role="tab"
         :aria-selected="tab.id === activeTab[props.position]"
         :aria-label="tab.label"
-        :aria-controls="`panel-${tab.id}`"
+        :aria-controls="`wm-panel-body-${ props.position }-${ tab.id.replace(/[^a-zA-Z0-9_-]/g, '-') }`"
         tabindex="0"
         @click="setTabActive({ position: props.position, id: tab.id })"
         @keyup.enter.space="setTabActive({ position: props.position, id: tab.id })"


### PR DESCRIPTION
## Summary

Multiple `HorizontalPanel` instances (top / bottom) were producing `aria-controls="panel-<tab-id>"` attributes that pointed to the same DOM id, breaking the aria-controls relationship. The reference is now scoped by panel position and the tab id is sanitised to a valid HTML id.

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Test plan
- [ ] `yarn lint`
- [ ] Existing unit tests pass
- [ ] `cypress/e2e/tests/accessibility/shell.spec.ts` no longer reports invalid `aria-controls` on the window-manager panel tabs
