### PR TITLE
a11y: Make nav Group aria-labels unique and use navigation role

### DIFF
--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -49,6 +49,11 @@ export default {
     highlightRoute: {
       type:    Boolean,
       default: true,
+    },
+
+    parentLabel: {
+      type:    String,
+      default: '',
     }
   },
 
@@ -103,6 +108,10 @@ export default {
 
     headerRoute() {
       return filterLocationValidParams(this.$router, this.group.children[0].route);
+    },
+
+    parentName() {
+      return this.depth > 0 ? `${ this.parentLabel }, ` : '';
     }
   },
 
@@ -271,9 +280,9 @@ export default {
         v-if="showHeader"
         class="header"
         :class="{'active': highlightRoute && isOverview, 'noHover': !canCollapse || fixedOpen}"
-        :role="hasChildren && !hasOverview ? 'button' : undefined"
+        :role="hasChildren && !hasOverview ? 'navigation' : undefined"
         :tabindex="hasChildren && !hasOverview ? (fixedOpen ? -1 : 0) : undefined"
-        :aria-label="hasChildren && !hasOverview ? (group.labelDisplay || group.label || '') : undefined"
+        :aria-label="hasChildren && !hasOverview ? `${ parentName }${ group.labelDisplay || group.label || '' }` : undefined"
         :aria-expanded="hasChildren && !hasOverview ? (!canCollapse || isExpanded) : undefined"
         :aria-controls="hasChildren && !hasOverview ? (!canCollapse ? null : `group-${id}`) : undefined"
         @click="groupSelected()"
@@ -362,6 +371,7 @@ export default {
             :group="child"
             :fixed-open="fixedOpen"
             :highlight-route="highlightRoute"
+            :parent-label="group.label"
             @selected="groupSelected($event)"
             @expand="expandGroup($event)"
             @close="close($event)"


### PR DESCRIPTION
## Summary

Nested `Group` components (e.g. items under "More Resources") were generating duplicate aria-labels for their header, making them ambiguous for screen-reader users. Nested groups now receive their parent label via a `parentLabel` prop and prepend it, so each header announces as `"<Parent>, <Child>"`.

Also corrects the header role from `button` to `navigation`, which is the appropriate landmark for a collapsible nav section toggle.

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Test plan
- [ ] `yarn lint`
- [ ] Existing unit tests pass
- [ ] Verify sidebar collapsing / expanding behaviour is unchanged
- [ ] `cypress/e2e/tests/accessibility/shell.spec.ts` reports no duplicate aria-label violations in the nav
