### PR TITLE
a11y: Fix incorrect ARIA role on Pinned cluster toggle

### DIFF
--- a/shell/components/nav/Pinned.vue
+++ b/shell/components/nav/Pinned.vue
@@ -36,7 +36,7 @@ export default {
     :aria-checked="!!pinned"
     class="pin icon"
     :class="{'icon-pin-outlined': !pinned, 'icon-pin': pinned}"
-    role="button"
+    role="checkbox"
     :aria-label="t('nav.ariaLabel.pinCluster', { cluster: cluster.label })"
     @click.stop.prevent="toggle"
     @keydown.enter.prevent="toggle"


### PR DESCRIPTION
## Summary

The pin icon on `Pinned.vue` represents a checked / unchecked state, so the correct role is `checkbox` rather than `button`. The `aria-checked` attribute was already present but was not semantically meaningful under `role="button"`.

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Test plan
- [ ] `yarn lint`
- [ ] Existing unit tests pass
- [ ] Manually verify pin / unpin behaviour on a cluster in the nav
