### PR TITLE
a11y: Stabilise kubectl-explain slide-in a11y test

### DIFF
--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -416,6 +416,10 @@ describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'] }, () =>
           slideIn.checkVisible();
           slideIn.waitforContent();
 
+          cy.wait(2500); // eslint-disable-line cypress/no-unnecessary-waiting
+
+          cy.get('[data-testid="kubectl-explain-expand-all"]').click();
+
           cy.injectAxe();
 
           cy.checkPageAccessibility();

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -209,6 +209,7 @@ export default {
       class="slide-in"
       :class="{ 'slide-in-open': isOpen }"
       :style="{ width, right, top, height }"
+      :aria-label="t('kubectl-explain.title')"
       data-testid="slide-in-panel-resource-explain"
     >
       <div
@@ -269,6 +270,7 @@ export default {
             class="icon icon-sort mr-10"
             role="button"
             :aria-label="t('kubectl-explain.expandAll')"
+            data-testid="kubectl-explain-expand-all"
             tabindex="0"
             @click="toggleAll()"
             @keydown.space.enter.stop.prevent="toggleAll()"


### PR DESCRIPTION
## Summary

The kubectl-explain slide-in panel a11y check was flaky because a tooltip attached to the last command was still animating when axe started scanning. Waits for the animation, then clicks the expand-all control so the panel content is fully rendered before injecting axe. Adds a matching test id on the expand-all icon and an aria-label on the slide-in panel itself.

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Test plan
- [ ] `yarn lint`
- [ ] `cypress/e2e/tests/accessibility/shell.spec.ts` (Secret - Describe Resource) is stable across multiple runs
