### PR TITLE
a11y: Give modal dialogs an accessible name (feedback pending)

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6020,6 +6020,7 @@ promptSlo:
     waiting: Logging Out
 
 promptRemove:
+  dialogAriaLabel: "Delete confirmation dialog"
   title: Are you sure?
   andOthers: |-
     {count, plural,

--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -91,7 +91,11 @@ export default defineComponent({
     focusTrapWatcherBasedVariable: {
       type:    Boolean,
       default: undefined,
-    }
+    },
+    title: {
+      type:    String,
+      default: '',
+    },
   },
   computed: {
     modalWidth(): string {
@@ -202,6 +206,7 @@ export default defineComponent({
           :class="customClass"
           class="modal-container"
           :style="modalStyles"
+          :aria-label="title"
           role="dialog"
           aria-modal="true"
           @click.stop

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -71,6 +71,19 @@ export default {
     },
     modalName() {
       return this.modalData?.modalName;
+    },
+
+    /**
+     * When the component is a string, we can generate a title from the name of the component which we can then use for the aria-label attribute.
+     * For example, if the component is "MyComponentDialog", we generate a title of "My Component Dialog"
+     */
+    modalTitle() {
+      if (typeof this.modalData?.component === 'string') {
+        // Insert a space before all caps and trim any leading/trailing whitespace
+        return this.modalData.component.replace(/([A-Z])/g, ' $1').trim();
+      }
+
+      return '';
     }
   },
 
@@ -124,6 +137,7 @@ export default {
     :custom-class="customClass"
     :styles="styles"
     :height="height"
+    :title="modalTitle"
     :trigger-focus-trap="true"
     :return-focus-selector="returnFocusSelector"
     :return-focus-first-iterable-node-selector="returnFocusFirstIterableNodeSelector"

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -341,6 +341,7 @@ export default {
     custom-class="remove-modal"
     name="promptRemove"
     :width="400"
+    :title="t('promptRemove.dialogAriaLabel')"
     height="auto"
     styles="max-height: 100vh;"
     :trigger-focus-trap="true"


### PR DESCRIPTION
## Summary

Modal dialogs without an accessible name were flagged by axe. `AppModal` now accepts an optional `title` prop that is applied as `aria-label` on the `role="dialog"` container. `PromptModal` derives a title from its component name (so registered prompt components get a sensible default), and `PromptRemove` passes an explicit translated label.

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Reviewer feedback outstanding
- [ ] Replace the regex-based title derivation in `PromptModal` with `_.startCase(...)` (rak-phillip on the original PR).

## Test plan
- [ ] `yarn lint`
- [ ] Existing unit tests pass
- [ ] Manually verify the Change Password dialog, PromptRemove confirmation dialog and other prompt-modal dialogs open, focus-trap and close correctly
- [ ] `cypress/e2e/tests/accessibility/shell.spec.ts` reports no missing-dialog-name violations
