### PR TITLE
a11y: Give the chart detail page a landmark label (feedback pending)

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -386,7 +386,10 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <main v-else>
+  <region
+    v-else
+    :aria-label="chart.chartNameDisplay"
+  >
     <div
       v-if="chart"
       class="chart-header"
@@ -579,6 +582,7 @@ export default {
       </div>
       <aside
         v-if="version"
+        :aria-label="t('catalog.chart.info.chartVersions.label')"
         class="chart-body__info"
       >
         <div class="chart-body__info-section">
@@ -743,7 +747,7 @@ export default {
         </div>
       </aside>
     </div>
-  </main>
+  </region>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Summary

The chart detail page's `<main>` had no accessible name, so axe flagged it as a missing landmark label. Replaces it with a labelled region and gives the version info `<aside>` its own aria-label so screen-reader users can navigate between them.

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Reviewer feedback outstanding
- [ ] `<region>` is not a valid HTML element - use a `div` (or `section`) with `role="region"` instead (rak-phillip on the original PR).
- [ ] Consider whether the aria-label duplicates the existing `<h1>` on the page and would cause screen readers to announce the same phrase twice.

## Test plan
- [ ] `yarn lint`
- [ ] Existing unit tests pass
- [ ] Manually verify the chart detail page layout is unchanged
- [ ] `cypress/e2e/tests/accessibility/shell.spec.ts` reports no landmark-unique / missing-landmark violations on the chart detail page
