### PR TITLE
a11y: Give OCI repo logo a distinct alt text (feedback pending)

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1434,8 +1434,9 @@ catalog:
       http: 
         title: Helm Repository
         description: HTTP(S) URL pointing to a Helm chart repository index
-      oci: 
+      oci:
         title: OCI Repository
+        logo: OCI Repository Logo
         description: OCI-compliant registry hosting Helm charts as artifacts
       suseAppCollection: 
         title: SUSE App Collection

--- a/shell/edit/catalog.cattle.io.clusterrepo.vue
+++ b/shell/edit/catalog.cattle.io.clusterrepo.vue
@@ -71,7 +71,7 @@ export default {
       {
         id:      CLUSTER_REPO_TYPES.OCI_URL,
         header:  { title: { key: 'catalog.repo.target.oci.title' } },
-        image:   { src: requireAsset('@shell/assets/images/providers/oci-open-containers.svg'), alt: { key: 'catalog.repo.target.oci.title' } },
+        image:   { src: requireAsset('@shell/assets/images/providers/oci-open-containers.svg'), alt: { key: 'catalog.repo.target.oci.title.logo' } },
         content: { key: 'catalog.repo.target.oci.description' },
       },
     ];


### PR DESCRIPTION
## Summary

The OCI cluster repo option was using the same translation key for its section heading and the logo alt text, so screen readers heard the same phrase twice. Adds a dedicated logo key and references it from the alt slot.

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Reviewer feedback outstanding
- [ ] Translation key mismatch: the code references `catalog.repo.target.oci.title.logo` but the new key in `en-us.yaml` is `catalog.repo.target.oci.logo` - the code needs updating so the alt actually resolves (rak-phillip on the original PR).

## Test plan
- [ ] `yarn lint`
- [ ] Manually verify the OCI repo option renders correctly on the Add Cluster Repository page and the logo has an alt attribute
- [ ] `cypress/e2e/tests/accessibility/shell.spec.ts` reports no image-alt violation for the OCI logo
