### PR TITLE
a11y: Fix Wizard step list role and aria-controls target (feedback pending)

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -812,6 +812,7 @@ export default {
               >
                 <div
                   v-if="step.name === activeStep.name || step.hidden"
+                  :id="'step-container-' + step.name"
                   :key="step.name"
                   class="step-container__step"
                   :class="{'hide': step.name !== activeStep.name && step.hidden}"

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -374,7 +374,7 @@ export default {
 
                     :id="step.name"
                     :class="{step: true, active: step.name === activeStep.name, disabled: !isAvailable(step)}"
-                    role="presentation"
+                    role="listitem"
                   >
                     <span
                       :aria-controls="'step-container-' + step.name"


### PR DESCRIPTION
## Summary

Wizard step list items had `role="presentation"`, which suppressed them from the accessibility tree; changed to `role="listitem"`. `CruResource` overrides the Wizard's default step body slot, so its step container needs the id that the Wizard's `aria-controls` attribute references (`step-container-<step.name>`).

Split from rancher/dashboard#17254. Contributes towards rancher/dashboard#17279.

## Reviewer feedback outstanding
- [ ] `Wizard.vue`: reviewer suggests changing the `ul` container's role to `tablist` rather than switching individual step items from `presentation` to `listitem`, since the design is tab-like (rak-phillip on the original PR).
- [ ] `CruResource.vue`: the fix works but leaks the Wizard's internal id-naming convention to slot consumers - consider having the Wizard supply the id itself so consumers don't need to know (rak-phillip on the original PR).

## Test plan
- [ ] `yarn lint`
- [ ] Existing unit tests pass
- [ ] Manually verify Wizard / multi-step form navigation works (e.g. cluster creation, git repo add)
- [ ] `cypress/e2e/tests/accessibility/shell.spec.ts` reports no aria-controls / presentation violations on wizard pages
